### PR TITLE
add option to control the http response and expose axios instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,22 +42,23 @@ const { TDAmeritrade, TDAccount, TDStreamer } = require('@knicola/tdameritrade')
 const config = {
     accessToken: 'access_token',
     apiKey: 'testClientId', // `@AMER.OAUTHAP` suffix is not required
+    returnFullResponse: false, // Set to true to return the full axios response (default: false)
 }
 
 // main api interface
 const api = new TDAmeritrade(config)
-const { data: accounts } = await api.getAccounts()
-const orders = api.getOrders(accounts[0].accountId).then(res => {
-    // do something with res.data ..
-    return res.data
+const accounts = await api.getAccounts()
+const orders = api.getOrders(accounts[0].accountId).then(orders => {
+    // do something with orders ..
+    return orders
 })
 
 // account specific interface
 const account = new TDAccount(accounts[0].accountId, config)
-const { data: orders } = account.getOrders()
+const orders = account.getOrders()
 
 // data streamer
-const { data: userPrincipals } = await api.getUserPrincipals([
+const userPrincipals = await api.getUserPrincipals([
     'streamerSubscriptionKeys',
     'streamerConnectionInfo',
 ])

--- a/README.md
+++ b/README.md
@@ -41,24 +41,30 @@ $ yarn add @knicola/tdameritrade
 const { TDAmeritrade, TDAccount, TDStreamer } = require('@knicola/tdameritrade')
 const config = {
     accessToken: 'access_token',
-    apiKey: 'testClientId' // `@AMER.OAUTHAP` suffix is not required
+    apiKey: 'testClientId', // `@AMER.OAUTHAP` suffix is not required
 }
 
 // main api interface
 const api = new TDAmeritrade(config)
-const accounts = await api.getAccounts()
-api.getOrders(accounts[0].accountId).then( ... )
+const { data: accounts } = await api.getAccounts()
+const orders = api.getOrders(accounts[0].accountId).then(res => {
+    // do something with res.data ..
+    return res.data
+})
 
 // account specific interface
 const account = new TDAccount(accounts[0].accountId, config)
-account.getOrders().then( ... )
+const { data: orders } = account.getOrders()
 
 // data streamer
-const userPrincipals = api.getUserPrincipals(['streamerSubscriptionKeys', 'streamerConnectionInfo'])
+const { data: userPrincipals } = await api.getUserPrincipals([
+    'streamerSubscriptionKeys',
+    'streamerConnectionInfo',
+])
 const streamer = new TDStreamer(userPrincipals)
 streamer.on('authenticated', () => streamer.subsChartEquity('SPY'))
 streamer.on('chart', data => {
-    // ..
+    // do something with chart data ..
 })
 streamer.connect()
 ```

--- a/src/http.js
+++ b/src/http.js
@@ -1,17 +1,25 @@
 'use strict'
 
 const axios = require('axios').default
-const pickBy = require('lodash/pickBy')
-const identity = require('lodash/identity')
+const defaults = require('./config')
+const apiKeySuffix = '@AMER.OAUTHAP'
 
-function http({ method = 'GET', url, params, data }) {
-    const headers = { Authorization: `Bearer ${this.config.accessToken}` }
-    return axios(
-        pickBy(
-            { method, url, params, data, headers, baseURL: this.config.baseURL },
-            identity
-        )
-    )
+function http(config) {
+    this.config = Object.assign({}, defaults, config, {
+        apiKey: (config.apiKey + '').endsWith(apiKeySuffix)
+            ? config.apiKey
+            : config.apiKey + apiKeySuffix
+    })
+
+    this.axios = axios.create({ baseURL: this.config.baseURL })
+
+    this.axios.interceptors.request.use(request => {
+        if (this.config.accessToken) {
+            request.headers.Authorization = `Bearer ${this.config.accessToken}`
+        }
+
+        return request
+    })
 } // http()
 
 module.exports = http

--- a/src/http.js
+++ b/src/http.js
@@ -20,6 +20,10 @@ function http(config) {
 
         return request
     })
+
+    if (! this.config.returnFullResponse) {
+        this.axios.interceptors.response.use(response => response.data)
+    }
 } // http()
 
 module.exports = http

--- a/src/resources/account.js
+++ b/src/resources/account.js
@@ -1,23 +1,19 @@
 'use strict'
 
 function getAccounts() {
-    return this.http({ url: '/accounts' })
+    return this.axios.get('/accounts')
 } // getAccounts()
 
 function getAccount(accountId) {
-    return this.http({ url: `/accounts/${accountId}` })
+    return this.axios.get(`/accounts/${accountId}`)
 } // getAccount()
 
 function getPreferences(accountId) {
-    return this.http({ url: `/accounts/${accountId}/preferences` })
+    return this.axios.get(`/accounts/${accountId}/preferences`)
 } // getPreferences()
 
 function updatePreferences(accountId, preferences) {
-    return this.http({
-        method: 'PUT',
-        url: `/accounts/${accountId}/preferences`,
-        data: preferences,
-    })
+    return this.axios.put(`/accounts/${accountId}/preferences`, preferences)
 } // updatePreferences()
 
 module.exports = {

--- a/src/resources/instrument.js
+++ b/src/resources/instrument.js
@@ -1,8 +1,7 @@
 'use strict'
 
 function searchInstruments(symbol, projection) {
-    return this.http({
-        url: '/instruments',
+    return this.axios.get('/instruments', {
         params: {
             symbol,
             projection,
@@ -12,8 +11,7 @@ function searchInstruments(symbol, projection) {
 } // searchInstruments()
 
 function getInstrument(cusip) {
-    return this.http({
-        url: `/instruments/${cusip}`,
+    return this.axios.get(`/instruments/${cusip}`, {
         params: {
             apikey: this.config.apiKey,
         }

--- a/src/resources/market.js
+++ b/src/resources/market.js
@@ -1,8 +1,7 @@
 'use strict'
 
 function getMarketHours(markets, date) {
-    return this.http({
-        url: '/marketdata/hours',
+    return this.axios.get('/marketdata/hours', {
         params: {
             markets: [].concat(markets).join(','),
             date,
@@ -12,8 +11,7 @@ function getMarketHours(markets, date) {
 } // getMarketHours()
 
 function getMovers(index, direction, change) {
-    return this.http({
-        url: `/marketdata/${index}/movers`,
+    return this.axios.get(`/marketdata/${index}/movers`, {
         params: {
             direction,
             change,
@@ -23,8 +21,7 @@ function getMovers(index, direction, change) {
 } // getMovers()
 
 function getQuotes(symbols) {
-    return this.http({
-        url: '/marketdata/quotes',
+    return this.axios.get('/marketdata/quotes', {
         params: {
             symbol: [].concat(symbols).join(','),
             apikey: this.config.apiKey,
@@ -33,8 +30,7 @@ function getQuotes(symbols) {
 } // getQuotes()
 
 function getQuote(symbol) {
-    return this.http({
-        url: `/marketdata/${symbol}/quotes`,
+    return this.axios.get(`/marketdata/${symbol}/quotes`, {
         params: {
             apikey: this.config.apiKey,
         },
@@ -42,15 +38,13 @@ function getQuote(symbol) {
 } // getQuote()
 
 function getPriceHistory(symbol, params) {
-    return this.http({
-        url: `/marketdata/${symbol}/pricehistory`,
+    return this.axios.get(`/marketdata/${symbol}/pricehistory`, {
         params: Object.assign({}, params, { apikey: this.config.apiKey }),
     })
 } // getPriceHistory()
 
 function getOptionChain(symbol, params) {
-    return this.http({
-        url: '/marketdata/chains',
+    return this.axios.get('/marketdata/chains', {
         params: Object.assign({}, params, { symbol, apikey: this.config.apiKey }),
     })
 } // getOptionChain()

--- a/src/resources/order.js
+++ b/src/resources/order.js
@@ -1,35 +1,27 @@
 'use strict'
 
 function getOrder(accountId, orderId) {
-    return this.http({ url: `/accounts/${accountId}/orders/${orderId}` })
+    return this.axios.get(`/accounts/${accountId}/orders/${orderId}`)
 } // getOrder()
 
 function getOrders(accountId, params) {
-    return this.http({ url: `/accounts/${accountId}/orders`, params })
+    return this.axios.get(`/accounts/${accountId}/orders`, { params })
 } // getOrders()
 
 function getAllOrders(params) {
-    return this.http({ url: '/orders', params })
+    return this.axios.get('/orders', { params })
 } // getAllOrders()
 
 function placeOrder(accountId, order) {
-    return this.http({
-        method: 'POST',
-        url: `/accounts/${accountId}/orders`,
-        data: order,
-    })
+    return this.axios.post(`/accounts/${accountId}/orders`, order)
 } // placeOrder()
 
 function replaceOrder(accountId, orderId, order) {
-    return this.http({
-        method: 'PUT',
-        url: `/accounts/${accountId}/orders/${orderId}`,
-        data: order,
-    })
+    return this.axios.put(`/accounts/${accountId}/orders/${orderId}`, order)
 } // replaceOrder()
 
 function cancelOrder(accountId, orderId) {
-    return this.http({ method: 'DELETE', url: `/accounts/${accountId}/orders/${orderId}` })
+    return this.axios.delete(`/accounts/${accountId}/orders/${orderId}`)
 } // cancelOrder()
 
 module.exports = {

--- a/src/resources/savedOrder.js
+++ b/src/resources/savedOrder.js
@@ -1,31 +1,23 @@
 'use strict'
 
 function getSavedOrder(accountId, savedOrderId) {
-    return this.http({ url: `/accounts/${accountId}/savedorders/${savedOrderId}` })
+    return this.axios.get(`/accounts/${accountId}/savedorders/${savedOrderId}`)
 } // getSavedOrder()
 
 function getSavedOrders(accountId) {
-    return this.http({ url: `/accounts/${accountId}/savedorders` })
+    return this.axios.get(`/accounts/${accountId}/savedorders`)
 } // getSavedOrdersByPath()
 
 function createSavedOrder(accountId, savedOrder) {
-    return this.http({
-        method: 'POST',
-        url: `/accounts/${accountId}/savedorders`,
-        data: savedOrder,
-    })
+    return this.axios.post(`/accounts/${accountId}/savedorders`, savedOrder)
 } // createSavedOrder()
 
 function replaceSavedOrder(accountId, savedOrderId, savedOrder) {
-    return this.http({
-        method: 'PUT',
-        url: `/accounts/${accountId}/savedorders/${savedOrderId}`,
-        data: savedOrder
-    })
+    return this.axios.put(`/accounts/${accountId}/savedorders/${savedOrderId}`, savedOrder)
 } // replaceSavedOrder()
 
 function deleteSavedOrder(accountId, savedOrderId) {
-    return this.http({ method: 'DELETE', url: `/accounts/${accountId}/savedorders/${savedOrderId}` })
+    return this.axios.delete(`/accounts/${accountId}/savedorders/${savedOrderId}`)
 } // deleteSavedOrder()
 
 module.exports = {

--- a/src/resources/token.js
+++ b/src/resources/token.js
@@ -1,38 +1,34 @@
 'use strict'
 
 function authorize(authorizationCode) {
-    return this.http({
-        method: 'POST',
-        url: '/oauth2/token',
-        data: {
+    return this.axios
+        .post('/oauth2/token', {
             grant_type: 'authorization_code',
             access_type: this.config.accessType || 'offline',
             client_id: `${this.config.apiKey}@AMER.OAUTHAP`,
             redirect_uri: this.config.redirectUri,
             code: authorizationCode || this.config.authorizationCode,
-        }
-    }).then(res => {
-        this.config.accessToken = res.data.access_token
-        this.config.refreshToken = res.data.refresh_token
-        return res
-    })
+        })
+        .then(res => {
+            this.config.accessToken = res.data.access_token
+            this.config.refreshToken = res.data.refresh_token
+            return res
+        })
 } // authorize()
 
 function refresh(refreshToken) {
-    return this.http({
-        method: 'POST',
-        url: '/oauth2/token',
-        data: {
+    return this.axios
+        .post('/oauth2/token', {
             grant_type: 'refresh_token',
             access_type: this.config.accessType || 'offline',
             client_id: `${this.config.apiKey}@AMER.OAUTHAP`,
             refresh_token: refreshToken || this.config.refreshToken,
-        }
-    }).then(res => {
-        this.config.accessToken = res.data.access_token
-        this.config.refreshToken = res.data.refresh_token
-        return res
-    })
+        })
+        .then(res => {
+            this.config.accessToken = res.data.access_token
+            this.config.refreshToken = res.data.refresh_token
+            return res
+        })
 } // refresh()
 
 module.exports = {

--- a/src/resources/transaction.js
+++ b/src/resources/transaction.js
@@ -1,11 +1,11 @@
 'use strict'
 
 function getTransaction(accountId, transactionId) {
-    return this.http({ url: `/accounts/${accountId}/transactions/${transactionId}` })
+    return this.axios.get(`/accounts/${accountId}/transactions/${transactionId}`)
 } // getTransaction()
 
 function getTransactions(accountId, params) {
-    return this.http({ url: `/accounts/${accountId}/transactions`, params })
+    return this.axios.get(`/accounts/${accountId}/transactions`, { params })
 } // getTransactions()
 
 module.exports = {

--- a/src/resources/userPrincipal.js
+++ b/src/resources/userPrincipal.js
@@ -1,20 +1,18 @@
 'use strict'
 
 function getStreamerSubscriptionKeys(accountIds) {
-    return this.http({
-        url: '/userprincipals/streamersubscriptionkeys',
+    return this.axios.get('/userprincipals/streamersubscriptionkeys', {
         params: {
-            accountIds: [].concat(accountIds).join(','),
-        },
+            accountIds: [].concat(accountIds).join(',')
+        }
     })
 } // getStreamerSubscriptionKeys()
 
 function getUserPrincipals(fields) {
-    return this.http({
-        url: '/userprincipals',
+    return this.axios.get('/userprincipals', {
         params: {
-            fields: [].concat(fields).join(','),
-        },
+            fields: [].concat(fields).join(',')
+        }
     })
 } // getUserPrincipals()
 

--- a/src/resources/watchlist.js
+++ b/src/resources/watchlist.js
@@ -1,46 +1,31 @@
 'use strict'
 
 function createWatchlist(accountId, watchlist) {
-    return this.http({
-        method: 'POST',
-        url: `/accounts/${accountId}/watchlists`,
-        data: watchlist,
-    })
+    return this.axios.post(`/accounts/${accountId}/watchlists`, watchlist)
 } // createWatchlist()
 
 function deleteWatchlist(accountId, watchlistId) {
-    return this.http({
-        method: 'DELETE',
-        url: `/accounts/${accountId}/watchlists/${watchlistId}`,
-    })
+    return this.axios.delete(`/accounts/${accountId}/watchlists/${watchlistId}`)
 } // deleteWatchlist()
 
 function getWatchlist(accountId, watchlistId) {
-    return this.http({ url: `/accounts/${accountId}/watchlists/${watchlistId}` })
+    return this.axios.get(`/accounts/${accountId}/watchlists/${watchlistId}`)
 } // getWatchlist()
 
 function getWatchlists(accountId) {
-    return this.http({ url: `/accounts/${accountId}/watchlists` })
+    return this.axios.get(`/accounts/${accountId}/watchlists`)
 } // getWatchlists()
 
 function getAllWatchlists() {
-    return this.http({ url: '/accounts/watchlists' })
+    return this.axios.get('/accounts/watchlists')
 } // getAllWatchlists()
 
 function replaceWatchlist(accountId, watchlistId, watchlist) {
-    return this.http({
-        method: 'PUT',
-        url: `/accounts/${accountId}/watchlists/${watchlistId}`,
-        data: watchlist,
-    })
+    return this.axios.put(`/accounts/${accountId}/watchlists/${watchlistId}`, watchlist)
 } // replaceWatchlist()
 
 function updateWatchlist(accountId, watchlistId, watchlist) {
-    return this.http({
-        method: 'PATCH',
-        url: `/accounts/${accountId}/watchlists/${watchlistId}`,
-        data: watchlist,
-    })
+    return this.axios.patch(`/accounts/${accountId}/watchlists/${watchlistId}`, watchlist)
 } // updateWatchlist()
 
 module.exports = {

--- a/src/tdAccount.js
+++ b/src/tdAccount.js
@@ -9,11 +9,8 @@ const watchlist = require('./resources/watchlist')
 const transaction = require('./resources/transaction')
 const userPrincipal = require('./resources/userPrincipal')
 
-const defaults = require('./config')
-
 function TDAccount(accountId, config) {
-    this.config = Object.assign({}, defaults, config)
-    this.http = http
+    http.call(this, config)
 
     // ACCOUNT INFO
     this.getAccount = partial(account.getAccount, accountId)

--- a/src/tdAmeritrade.js
+++ b/src/tdAmeritrade.js
@@ -10,18 +10,9 @@ const savedOrder = require('./resources/savedOrder')
 const watchlist = require('./resources/watchlist')
 const transaction = require('./resources/transaction')
 
-const defaults = require('./config')
-const apiKeySuffix = '@AMER.OAUTHAP'
-
 function TDAmeritrade(config) {
-    this.config = Object.assign({}, defaults, config, {
-        apiKey: (config.apiKey + '').endsWith(apiKeySuffix)
-            ? config.apiKey
-            : config.apiKey + apiKeySuffix
-    })
-} // TDAmeritrade()
-
-TDAmeritrade.prototype.http = http
+    http.call(this, config)
+}
 
 // MARKET
 TDAmeritrade.prototype.getMarketHours = market.getMarketHours

--- a/tests/TDAmeritrade.spec.js
+++ b/tests/TDAmeritrade.spec.js
@@ -22,7 +22,7 @@ describe('TDAmeritrade', () => {
         it('should get all Accounts', () => {
             return api
                 .getAccounts()
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts',
@@ -35,7 +35,7 @@ describe('TDAmeritrade', () => {
         it('should get a single account', () => {
             return api
                 .getAccount('123')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123',
@@ -48,7 +48,7 @@ describe('TDAmeritrade', () => {
         it('should get the user principals', () => {
             return api
                 .getUserPrincipals()
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/userprincipals',
@@ -59,7 +59,7 @@ describe('TDAmeritrade', () => {
         it('should get the user principals with additional fields', () => {
             return api
                 .getUserPrincipals(['field-one', 'field-two'])
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/userprincipals',
@@ -73,7 +73,7 @@ describe('TDAmeritrade', () => {
         it('should get a single account', () => {
             return api
                 .getStreamerSubscriptionKeys(['some-account', 'some-other-account'])
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/userprincipals/streamersubscriptionkeys',
@@ -87,7 +87,7 @@ describe('TDAmeritrade', () => {
         it('should get the account\'s preferences', () => {
             return api
                 .getPreferences('123')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/preferences',
@@ -100,7 +100,7 @@ describe('TDAmeritrade', () => {
         it('should update the account\'s preferences', () => {
             return api
                 .updatePreferences('123', { field: 'new value' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'PUT',
                         url: '/accounts/123/preferences',
@@ -114,7 +114,7 @@ describe('TDAmeritrade', () => {
         it('should get all orders from all accounts', () => {
             return api
                 .getAllOrders()
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/orders',
@@ -125,7 +125,7 @@ describe('TDAmeritrade', () => {
         it('should get all orders from all accounts using a filter', () => {
             return api
                 .getAllOrders({ filter: 'value' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/orders',
@@ -139,7 +139,7 @@ describe('TDAmeritrade', () => {
         it('should get all orders from a single account', () => {
             return api
                 .getOrders('123')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/orders',
@@ -150,7 +150,7 @@ describe('TDAmeritrade', () => {
         it('should get all orders from a single account using a filter', () => {
             return api
                 .getOrders('123', { filter: 'value' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/orders',
@@ -164,7 +164,7 @@ describe('TDAmeritrade', () => {
         it('should get a single order from a single account', () => {
             return api
                 .getOrder('123', '456')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/orders/456',
@@ -177,7 +177,7 @@ describe('TDAmeritrade', () => {
         it('should place a new order', () => {
             return api
                 .placeOrder('123', { name: 'new order' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'POST',
                         url: '/accounts/123/orders',
@@ -191,7 +191,7 @@ describe('TDAmeritrade', () => {
         it('should replace an existing order', () => {
             return api
                 .replaceOrder('123', '456', { name: 'updated order' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'PUT',
                         url: '/accounts/123/orders/456',
@@ -205,7 +205,7 @@ describe('TDAmeritrade', () => {
         it('should cancel an existing order', () => {
             return api
                 .cancelOrder('123', '456')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'DELETE',
                         url: '/accounts/123/orders/456',
@@ -218,7 +218,7 @@ describe('TDAmeritrade', () => {
         it('should get all saved orders of a single account', () => {
             return api
                 .getSavedOrders('123')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/savedorders',
@@ -231,7 +231,7 @@ describe('TDAmeritrade', () => {
         it('should get an existing saved order', () => {
             return api
                 .getSavedOrder('123', '456')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/savedorders/456',
@@ -244,7 +244,7 @@ describe('TDAmeritrade', () => {
         it('should create a new saved order', () => {
             return api
                 .createSavedOrder('123', { name: 'new saved order' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'POST',
                         url: '/accounts/123/savedorders',
@@ -258,7 +258,7 @@ describe('TDAmeritrade', () => {
         it('should create a new saved order', () => {
             return api
                 .replaceSavedOrder('123', '456', { name: 'updated saved order' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'PUT',
                         url: '/accounts/123/savedorders/456',
@@ -272,7 +272,7 @@ describe('TDAmeritrade', () => {
         it('should create a new saved order', () => {
             return api
                 .deleteSavedOrder('123', '456')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'DELETE',
                         url: '/accounts/123/savedorders/456',
@@ -285,7 +285,7 @@ describe('TDAmeritrade', () => {
         it('should get all watchlists for all accounts', () => {
             return api
                 .getAllWatchlists()
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/watchlists',
@@ -298,7 +298,7 @@ describe('TDAmeritrade', () => {
         it('should get all watchlists for a single account', () => {
             return api
                 .getWatchlists('123')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/watchlists',
@@ -311,7 +311,7 @@ describe('TDAmeritrade', () => {
         it('should get a single watchlist', () => {
             return api
                 .getWatchlist('123', '456')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/watchlists/456',
@@ -324,7 +324,7 @@ describe('TDAmeritrade', () => {
         it('should create a new watchlist', () => {
             return api
                 .createWatchlist('123', { name: 'new watchlist' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'POST',
                         url: '/accounts/123/watchlists',
@@ -338,7 +338,7 @@ describe('TDAmeritrade', () => {
         it('should replace an existing watchlist', () => {
             return api
                 .replaceWatchlist('123', '456', { name: 'updated watchlist' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'PUT',
                         url: '/accounts/123/watchlists/456',
@@ -352,7 +352,7 @@ describe('TDAmeritrade', () => {
         it('should update an existing watchlist', () => {
             return api
                 .updateWatchlist('123', '456', { name: 'updated watchlist' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'PATCH',
                         url: '/accounts/123/watchlists/456',
@@ -366,7 +366,7 @@ describe('TDAmeritrade', () => {
         it('should delete an existing watchlist', () => {
             return api
                 .deleteWatchlist('123', '456')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'DELETE',
                         url: '/accounts/123/watchlists/456',
@@ -379,7 +379,7 @@ describe('TDAmeritrade', () => {
         it('should get transaction history for a specific account', () => {
             return api
                 .getTransactions('123')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/transactions',
@@ -390,7 +390,7 @@ describe('TDAmeritrade', () => {
         it('should get transaction history for a specific account using a filter', () => {
             return api
                 .getTransactions('123', { name: 'some-filter' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/transactions',
@@ -404,7 +404,7 @@ describe('TDAmeritrade', () => {
         it('should get a single transaction for a specific account', () => {
             return api
                 .getTransaction('123', '456')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/accounts/123/transactions/456',
@@ -417,7 +417,7 @@ describe('TDAmeritrade', () => {
         it('should get market hours for a specific date', () => {
             return api
                 .getMarketHours('equity', '2020-01-01')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/marketdata/hours',
@@ -431,7 +431,7 @@ describe('TDAmeritrade', () => {
         it('should get mover information by index symbol, direction type and change', () => {
             return api
                 .getMovers('index', 'direction', 'change')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/marketdata/index/movers',
@@ -445,7 +445,7 @@ describe('TDAmeritrade', () => {
         it('should get quotes for one or more symbols', () => {
             return api
                 .getQuotes(['symbol1', 'symbol2'])
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/marketdata/quotes',
@@ -459,7 +459,7 @@ describe('TDAmeritrade', () => {
         it('should get quotes for one or more symbols', () => {
             return api
                 .getQuote('symbol1')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/marketdata/symbol1/quotes',
@@ -473,7 +473,7 @@ describe('TDAmeritrade', () => {
         it('should get price history for a symbol', () => {
             return api
                 .getPriceHistory('symbol1')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/marketdata/symbol1/pricehistory',
@@ -485,7 +485,7 @@ describe('TDAmeritrade', () => {
         it('should get price history for a symbol using a filter', () => {
             return api
                 .getPriceHistory('symbol1', { name: 'some filter' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/marketdata/symbol1/pricehistory',
@@ -499,7 +499,7 @@ describe('TDAmeritrade', () => {
         it('should get option chain for an optionable Symbol', () => {
             return api
                 .getOptionChain('symbol1')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/marketdata/chains',
@@ -511,7 +511,7 @@ describe('TDAmeritrade', () => {
         it('should get option chain for an optionable Symbol using a filter', () => {
             return api
                 .getOptionChain('symbol1', { name: 'some filter' })
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/marketdata/chains',
@@ -525,7 +525,7 @@ describe('TDAmeritrade', () => {
         it('should get an instrument by CUSIP', () => {
             return api
                 .getInstrument('some-cusip')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/instruments/some-cusip',
@@ -539,7 +539,7 @@ describe('TDAmeritrade', () => {
         it('should search or retrieve instrument data, including fundamental data', () => {
             return api
                 .searchInstruments('symbol1', 'symbol-search')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         method: 'GET',
                         url: '/instruments',
@@ -556,9 +556,27 @@ describe('TDAmeritrade', () => {
             }))
             return api
                 .getQuote('symbol')
-                .then(({data}) => {
+                .then(data => {
                     assertApiCall(data, {
                         params: expectedApiKey,
+                    })
+                })
+        })
+        it('should return the full axios response, if `returnFullResponse` is set to true', () => {
+            const api = new TDAmeritrade(Object.assign({}, config, {
+                returnFullResponse: true
+            }))
+            return api
+                .getQuote('symbol')
+                .then(res => {
+                    expect(res).toHaveProperty('data')
+                    expect(res).toHaveProperty('headers')
+                    expect(res).toHaveProperty('status', 200)
+                    assertApiCall(res.data, {
+                        method: 'GET',
+                        url: '/marketdata/symbol/quotes',
+                        params: expectedApiKey,
+                        headers: expectedAuthorization,
                     })
                 })
         })


### PR DESCRIPTION
Add an option to control how the HTTP response is returned. From now on the API client will return body of the response, by default, but if `config.returnFullResponse` is set to `true` it will return the full axios HTTP response instead.

Also, expose the axios instance on both `TDAmeritrade` and `TDAccount` interfaces (eg. `TDAmeritrade.axios`) to allow the user to add interceptors.