### PR TITLE
clean-up types

### DIFF
--- a/src/client/resources/market.js
+++ b/src/client/resources/market.js
@@ -97,13 +97,13 @@ function getQuote(symbol) {
  *      - `month` : 1*, 2, 3, 6
  *      - `year` : 1*, 2, 3, 5, 10, 15, 20
  *      - `ytd` : 1*
- * @property {'day'|'month'|'year'|'ytd'} frequencyType The type of frequency with which a new candle is formed
+ * @property {'minute'|'daily'|'weekly'|'monthly'} frequencyType The type of frequency with which a new candle is formed
  *      - `day` : minute*
  *      - `month` : daily, weekly*
  *      - `year` : daily, weekly, monthly*
  *      - `ytd` : daily, weekly*
- * @property {string} startDate Start date as milliseconds since epoch. If `startDate` and `endDate` are provided, period should not be provided
- * @property {string} endDate End date as milliseconds since epoch. If `startDate` and `endDate` are provided, period should not be provided. Default is previous trading day
+ * @property {string} [startDate] Start date as milliseconds since epoch. If `startDate` and `endDate` are provided, period should not be provided
+ * @property {string} [endDate] End date as milliseconds since epoch. If `startDate` and `endDate` are provided, period should not be provided. Default is previous trading day
  * @property {boolean} [needExtendedHoursData=true] Include extended hours data. Default is `true`
  */
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -955,15 +955,15 @@ export type PriceHistoryQuery = {
      *      - `year` : daily, weekly, monthly*
      *      - `ytd` : daily, weekly*
      */
-    frequencyType: 'day'|'month'|'year'|'ytd';
+    frequencyType: 'minute'|'daily'|'weekly'|'monthly';
     /**
      * Start date as milliseconds since epoch. If `startDate` and `endDate` are provided, period should not be provided
      */
-    startDate: string;
+    startDate?: string;
     /**
      * End date as milliseconds since epoch. If `startDate` and `endDate` are provided, period should not be provided. Default is previous trading day
      */
-    endDate: string;
+    endDate?: string;
     /**
      * Include extended hours data. Default is `true`
      */


### PR DESCRIPTION
Per your earlier request, here's a corrected update to the types/index.ts file via JSDoc comments. 

1. Per documentation at: https://developer.tdameritrade.com/price-history/apis/get/marketdata/%7Bsymbol%7D/pricehistory
    The values for frequencyType should be: 'minute' | 'daily' | 'weekly' | 'monthly'
2. startDate and endDate are optional parameters

