### PR TITLE
Custom error response

### DIFF
--- a/src/client/interceptors.js
+++ b/src/client/interceptors.js
@@ -81,6 +81,29 @@ function fullResponse(client) {
         return client.config.returnFullResponse
             ? response
             : get(response, 'data')
+    }, error => {
+        // we don't want to Promise.reject() as it will
+        // trigger an ERR_UNHANDLED_REJECTION error.
+
+        // axios response
+        if (client.config.returnFullResponse) {
+            throw error
+        }
+
+        // custom error response
+        if (error.response) {
+            const customError = {
+                status: get(error, 'response.status'),
+                error: get(error, 'response.data.error'),
+            }
+
+            throw customError
+        }
+
+        // extract error
+        const customError = new Error(error.message)
+        customError.stack = error.stack
+        throw customError
     })
 } // fullResponse()
 

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -900,7 +900,7 @@ describe('Client', () => {
                     })
                 })
         }) // test
-        it('should return the full axios response, if `returnFullResponse` is set to true', () => {
+        it('should return axios response, if `returnFullResponse` is TRUE', () => {
             const api = new Client(Object.assign({}, config, {
                 returnFullResponse: true
             }))
@@ -917,6 +917,63 @@ describe('Client', () => {
                         headers: expectedAuthorization,
                     })
                 })
+        }) // test
+        it('should return the axios error reponse, if `returnFullResponse` is TRUE', async () => {
+            const api = new Client(Object.assign({}, config, {
+                returnFullResponse: true
+            }))
+            mockAxios.reset()
+            mockAxios.onAny().replyOnce(404, {
+                error: 'nothing to see here'
+            })
+            mockAxios.onAny().networkErrorOnce()
+            // server error
+            await api
+                .getQuote('symbol')
+                .then(() => 'should never happen')
+                .catch(err => {
+                    expect(err).toHaveProperty('isAxiosError', true)
+                })
+                .then(res => expect(res).toBeUndefined())
+            // network error
+            await api
+                .getQuote('symbol')
+                .then(() => 'should never happen')
+                .catch(err => {
+                    expect(err).toHaveProperty('isAxiosError', true)
+                })
+                .then(res => expect(res).toBeUndefined())
+        }) // test
+        it('should return custom error, if `returnFullResponse` is FALSE', async () => {
+            const api = new Client(Object.assign({}, config, {
+                returnFullResponse: false
+            }))
+            mockAxios.reset()
+            mockAxios.onAny().replyOnce(404, {
+                error: 'nothing to see here'
+            })
+            mockAxios.onAny().networkErrorOnce()
+            // server error
+            await api
+                .getQuote('symbol')
+                .then(() => 'should never happen')
+                .catch(err => {
+                    expect(err).toStrictEqual({
+                        error: 'nothing to see here',
+                        status: 404
+                    })
+                })
+                .then(res => expect(res).toBeUndefined())
+            // network error
+            await api
+                .getQuote('symbol')
+                .then(() => 'should never happen')
+                .catch(err => {
+                    expect(err).toHaveProperty('message', 'Network Error')
+                    expect(err).toHaveProperty('stack')
+                    expect(err.stack.startsWith('Error: Network Error')).toBeTruthy()
+                })
+                .then(res => expect(res).toBeUndefined())
         }) // test
         it('should refresh token on 401 response and retry request, if `refreshAndRetry` is set to TRUE', () => {
             const api = new Client(Object.assign({}, config, {

--- a/tests/node.spec.js
+++ b/tests/node.spec.js
@@ -119,7 +119,7 @@ describe('TDAmeritrade (Node.js)', () => {
             })
             return td.authorize().catch(err => {
                 expect(err).not.toBeUndefined()
-                expect(err.response.status).toEqual(500)
+                expect(err.status).toEqual(500)
             })
         }) // test
         it('should default to port 8443 if redirectUri does not specify one', () => {
@@ -133,7 +133,7 @@ describe('TDAmeritrade (Node.js)', () => {
             })
             return td.authorize().then(res => {
                 expect(res).toEqual({ success: true })
-            })
+            }).catch(err => expect(err).toBeUndefined())
         }) // test
     }) // group
     describe('.login()', () => {


### PR DESCRIPTION
> Introducing a potentially breaking change to the error handling of the API client.

The API client always returns the axios error response, even when `returnFullResponse` option is set to `false`.

This PR introduces a custom server error response if `returnFullResponse` is set to `false` (which is by default).
```js
// 404 error
{
    error: "Page Not Found",
    status: 404
}
```
Any non-server error responses, such as a Network Error, will be returned as an `Error()` obj.
```js
// Network Error
console.log(err.message) //=> Network Error
console.log(err.stack) //=> Error: Network Error
//    at Object.createAxiosError ...[rest of stack trace]...
```